### PR TITLE
Fixing bad regex

### DIFF
--- a/pushover-weechat.rb
+++ b/pushover-weechat.rb
@@ -122,9 +122,9 @@ def notify(data, signal, signal_data)
   end
 
   if signal == "weechat_pv"
-    event = "Weechat Private message from " + (signal_data.split(' '))[0]
+    event = "Weechat Private message from #{signal_data.split.first}"
   elsif signal == "weechat_highlight"
-    event = "Weechat Highlight from " + (signal_data.split(' '))[0]
+    event = "Weechat Highlight from #{signal_data.split.first}"
   end
 
   if (Time.now - @last) > Weechat.config_get_plugin('interval').to_i


### PR DESCRIPTION
I created a bug with my regex. Weechat uses a tab and not a space to separate out the username from the message. I'm surprised that `split(' ')` matches a tab:

``` irb
>> "this\thas a tab".split(" ")
=> ["this", "has", "a", "tab"]
```
