### PR TITLE
fix for UTF_7 issue

### DIFF
--- a/pushover-weechat.rb
+++ b/pushover-weechat.rb
@@ -74,6 +74,9 @@
 #           none - None (silent)
 #       Default: blank (Sound will be device default tone set in Pushover)
 
+# fix for weechat UTF_7 encoding issue
+require 'enc/encdb.so'
+
 require 'rubygems'
 require 'net/https'
 


### PR DESCRIPTION
This affects fedora 22 & centos 7.1's version of weechat (and anything that requires uri apparently)

found the solution on https://github.com/weechat/weechat/issues/433 - this fixed loading the script with weechat 1.3 (rpm weechat-1.3-1.gf.el7.x86_64)