### PR TITLE
adds an option to not notify about certain highlights

### DIFF
--- a/pushover-weechat.rb
+++ b/pushover-weechat.rb
@@ -73,6 +73,11 @@
 #           updown - Up Down (long)
 #           none - None (silent)
 #       Default: blank (Sound will be device default tone set in Pushover)
+#
+#   plugins.var.ruby.pushover-weechat.ignore_re
+#
+#       Regular expression to skip certain kinds of highlights
+#
 
 # fix for weechat UTF_7 encoding issue
 require 'enc/encdb.so'
@@ -131,6 +136,10 @@ def notify(data, signal, signal_data)
   end
 
   if (Time.now - @last) > Weechat.config_get_plugin('interval').to_i
+    message = signal_data[/^\S+\t(.*)/, 1]
+    if ignore_re = Weechat.config_get_plugin('ignore_re')
+      return Weechat::WEECHAT_RC_OK if message =~ Regexp.new(ignore_re, true)
+    end
     url = URI.parse("https://api.pushover.net/1/messages")
     req = Net::HTTP::Post.new(url.path)
     req.set_form_data({
@@ -138,7 +147,7 @@ def notify(data, signal, signal_data)
       :user    => Weechat.config_get_plugin('userkey'),
       :sound   => Weechat.config_get_plugin('sound'),
       :title   => event,
-      :message => signal_data[/^\S+\t(.*)/, 1]
+      :message => message
     })
     res = Net::HTTP.new(url.host, url.port)
     res.use_ssl = true


### PR DESCRIPTION
This introduces a new option which can be set to a regular expression. messages that result in a highlight, but match this expression, will not be pushed.