### PR TITLE
Fixed message parsing that was accidentally removed

### DIFF
--- a/pushover-weechat.rb
+++ b/pushover-weechat.rb
@@ -137,6 +137,7 @@ def notify(data, signal, signal_data)
   end
 
   if (Time.now - @last) > Weechat.config_get_plugin('interval').to_i
+    message = signal_data[/^\S+\t(.*)/, 1]
     url = URI.parse("https://api.pushover.net/1/messages.json")
     req = Net::HTTP::Post.new(url.path, 'Content-Type' => 'application/json')
     req.body = JSON.generate({


### PR DESCRIPTION
In one of the latest commits in this repo when it was changed to the JSON API this line was accidentally removed which made it not work for me.

Putting it back seems to fix the issue.